### PR TITLE
Add serialisation detail

### DIFF
--- a/docs/libraries/core/serialisation.md
+++ b/docs/libraries/core/serialisation.md
@@ -1,3 +1,23 @@
+# Serialisation
+
+Serialisation is the process of writing objects to and output format and reading them back in. The serialisation framework is designed to be extensible and support a wide range of format, including both binary and text based serialisation.  
+
+Within the framework their are concepts defining interfaces for readers and writers. Reader and writers support a basic set of fundamental operation which must be support for the framework to convert the data of supported types to the serialisation format. Currently supported formats include:
+ - Json
+
+Longer term there is intend to be support for the following formats
+- Binary
+- Json
+- Yaml
+- Toml
+- Xml
+- HDF5
+- MessagePack: https://msgpack.org/index.html
+- Protobuf
+- Cap'n Proto
+
+
+
 # Serialisation specifications:
 - ASN.1: https://en.wikipedia.org/wiki/ASN.1
 
@@ -21,16 +41,6 @@
 - Thrift: https://thrift.apache.org/
 - YAS: https://github.com/niXman/yas
 - zpp::bits: https://github.com/eyalz800/zpp_bits
-
-# Supported formats
-- Binary
-- Json
-- Yaml
-- Toml
-- Xml
-- MessagePack: https://msgpack.org/index.html
-- Protobuf
-- Cap'n Proto
 
 
 

--- a/docs/libraries/core/serialisation.md
+++ b/docs/libraries/core/serialisation.md
@@ -16,6 +16,19 @@ Longer term there is intend to be support for the following formats
 - Protobuf
 - Cap'n Proto
 
+## Entry Points
+
+The serialisation framework is based on 2 entry points, `serialise` and `deserialise` which are [customisation point object (CPOs)](https://quuxplusone.github.io/blog/2018/03/19/customization-points-for-functions/).  These CPOs do the work of then dispatching to an appropriate overload for the actual type being serialised.
+
+## Reader and Writers
+
+The serialisation framework provides concepts for readers and writers, which are interfaces specifying how read and write the fundmental primitive types supported by the C++ language.  All serialisation is build upon these basic building blocks.
+
+.. doxygenconcept:: morpheus::serialisation::concepts::Reader
+   :project: morpheus_core
+
+.. doxygenconcept:: morpheus::serialisation::concepts::Writer
+   :project: morpheus_core
 
 
 # Serialisation specifications:
@@ -46,9 +59,3 @@ Longer term there is intend to be support for the following formats
 
 # Toml Sax Parsers
 - loltoml: https://github.com/andrusha97/loltoml
-
-
-
-# Target Features
-- Binary format
-	- 


### PR DESCRIPTION
@jakeheke75 I'm beginning to add documentation for the serialisation framework here.  This will be built by the documentation target in the checks and when the PR if committed then it will be deployed to the project's Github pages: https://github.com/Twon/Morpheus/actions/runs/5353663664/jobs/9709779731?pr=170