### PR TITLE
Intel oneAPI DPC++/C++ Compiler support

### DIFF
--- a/.conan/profiles/compiler/intel
+++ b/.conan/profiles/compiler/intel
@@ -1,0 +1,19 @@
+[settings]
+compiler=intel-cc
+compiler.mode=icx
+
+{% set os = detect_api.detect_os() %}
+{% if os == "Linux" %}
+[conf]
+tools.intel:installation_path=/opt/intel/oneapi/
+[buildenv]
+CC=icx
+CXX=icpx
+{% endif %}
+{% if os == "Windows" %}
+[conf]
+tools.intel:installation_path=C:\Program Files (x86)\Intel\oneAPI
+[buildenv]
+CC=icx
+CXX=icx
+{% endif %}

--- a/.conan/profiles/intel/2023.2/compiler
+++ b/.conan/profiles/intel/2023.2/compiler
@@ -1,0 +1,4 @@
+include(../../compiler/intel)
+
+[settings]
+compiler.version=2023.2

--- a/.conan/profiles/intel/2023.2/x64-libstdc++-debug
+++ b/.conan/profiles/intel/2023.2/x64-libstdc++-debug
@@ -1,0 +1,7 @@
+include(../../default)
+include(../../arch/x64)
+include(../../cpp/23)
+include(../../config/debug)
+include(../../os/current)
+include(../../packages/settings)
+include(compiler)

--- a/.conan/profiles/intel/2023.2/x64-libstdc++-msr
+++ b/.conan/profiles/intel/2023.2/x64-libstdc++-msr
@@ -1,0 +1,7 @@
+include(../../default)
+include(../../arch/x64)
+include(../../cpp/23)
+include(../../config/min-size-rel)
+include(../../os/current)
+include(../../packages/settings)
+include(compiler)

--- a/.conan/profiles/intel/2023.2/x64-libstdc++-release
+++ b/.conan/profiles/intel/2023.2/x64-libstdc++-release
@@ -1,0 +1,7 @@
+include(../../default)
+include(../../arch/x64)
+include(../../cpp/23)
+include(../../config/release)
+include(../../os/current)
+include(../../packages/settings)
+include(compiler)

--- a/.conan/profiles/intel/2023.2/x64-libstdc++-rwdi
+++ b/.conan/profiles/intel/2023.2/x64-libstdc++-rwdi
@@ -1,0 +1,7 @@
+include(../../default)
+include(../../arch/x64)
+include(../../cpp/23)
+include(../../config/rel-with-deb-info)
+include(../../os/current)
+include(../../packages/settings)
+include(compiler)

--- a/.conan/profiles/packages/settings
+++ b/.conan/profiles/packages/settings
@@ -1,5 +1,5 @@
 {% set os = detect_api.detect_os() %}
-{% if os == "Linux" -%}
+{% if os == "Linux" %}
 [settings]
 mold*:build_type=Release
 onetbb*:build_type=Release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ include(GNUInstallDirs)
 include(CMakeDependentOption)
 include(CMakePackageConfigHelpers)
 
+option(MORPHEUS_BUILD_WITH_INTEL "Enable Intel oneAPI DPC++/C++ Compiler" ON)
 option(MORPHEUS_LINK_WITH_MOLD "Enable the mold linker" ON)
 cmake_dependent_option(MORPHEUS_CODE_COVERAGE "Enable code coverage" ON "\"${CMAKE_CXX_COMPILER_ID}\" STREQUAL \"Clang\" OR \"${CMAKE_CXX_COMPILER_ID}\" STREQUAL \"GNU\"" OFF)
 cmake_dependent_option(MORPHEUS_INCLUDE_NATVIS "Enable inclusion of a natvis files for debugging" ON "\"${CMAKE_CXX_COMPILER_ID}\" STREQUAL \"MSVC\"" OFF)

--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -33,4 +33,12 @@ target_compile_options(MorpheusConfig
         $<$<CXX_COMPILER_ID:MSVC>:${MSVC_WARNINGS}>
         $<$<CXX_COMPILER_ID:GNU>:${GCC_WARNINGS}>
         $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:${CLANG_WARNINGS}>
+        <$<CXX_COMPILER_ID:IntelLLVM>:${CLANG_WARNINGS}>
 )
+
+if (${MORPHEUS_BUILD_WITH_INTEL})
+    find_package(IntelSYSCL REQUIRED)
+    message(STATUS "Morpheus: found Intel One API DPC++/C++ Compiler.")
+    set(CMAKE_C_COMPILER icx PARENT_SCOPE)
+    set(CMAKE_CXX_COMPILER icpx PARENT_SCOPE)
+endif()

--- a/cmake/linker.cmake
+++ b/cmake/linker.cmake
@@ -17,7 +17,7 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 
 include_guard(GLOBAL)
 
-if (${MORPHEUS_LINK_WITH_MOLD})
+if (${MORPHEUS_LINK_WITH_MOLD} AND NOT ${MORPHEUS_BUILD_WITH_INTEL})
     find_program(MOLD_BIN mold REQUIRED)
     if(MOLD_BIN)
         message(STATUS "Morpheus: Mold linker found: ${MOLD_BIN}.  Enabling mold as active linker.")

--- a/conanfile.py
+++ b/conanfile.py
@@ -75,7 +75,7 @@ class Morpheus(ConanFile):
         "glew/2.2.0",
         "gtest/1.13.0",
         "magic_enum/0.8.2",
-        "ms-gsl/4.0.0",
+        #"ms-gsl/4.0.0",
         "rapidjson/cci.20220822",
         "range-v3/0.12.0",
         "tl-expected/20190710",
@@ -135,7 +135,7 @@ class Morpheus(ConanFile):
     @property
     def _minimum_compilers_version(self):
         return {
-#            "intel-cc": "??"
+            "intel-cc": "2023.2",
             "msvc": "16",
             "gcc": "11",
             "clang": "13",


### PR DESCRIPTION
Hello Antony,

This is a draft PR to integrate the build process with the Intel oneAPI DPC++/C++ Compiler #58 #218.
Initially in my mind I had the following integration process:

- integrate the build process in Windows
- integrate the build process in Linux
- integrate the Github workflow for both of them

No joy. I started with the first step and immediately had to fight with compilation issues. Below the steps done (starting from a clean repository situation):

- Install the [Intel oneAPI Base Toolkit with Visual Studio support](https://www.intel.com/content/www/us/en/docs/oneapi/installation-guide-windows/2023-2/overview.html)
- Manual update of `settings.yml` file in order to add versions of the intel-cc compiler
```yaml
    intel-cc:
        version: ["2021.1", "2021.2", "2021.3", "2021.4", "2022.0", "2022.1", "2022.2", "2022.3", "2023.0", "2023.1", "2023.2" ]
```
- Launch the Intel oneAPI command prompt for Intel 64 for Visual Studio and execute the following commands:
- `python -m venv .venv`
- `.venv\Scripts\activate.bat`
- `pip install -r ./requirements.txt`
- `conan profile detect --force`
- `conan config install ./.conan`
- `conan install ./ -pr:h .conan2/profiles/intel/2023.2/x64-libstdc++-release -pr:b .conan2/profiles/intel/2023.2/x64-libstdc++-release --build missing -c tools.cmake.cmaketoolchain:generator="Ninja Multi-Config"`

Immediately getting error message about package `ms-gsl/4.0.0`:

```python
ERROR: ms-gsl/4.0.0: Error in validate() method, line 70
        self.output.warn(f"{self.ref} requires C++{self._minimum_cpp_standard}. "
        AttributeError: 'ConanOutput' object has no attribute 'warn'
```	
the Intel oneAPI compiler is not available for the package, here is a code snippet of the Conan recipe where it is triggering the error:
```python
    def _compilers_minimum_version(self):
        return {
            "gcc": "5",
            "clang": "3.4",
            "apple-clang": "3.4",
        }
```
Only for testing purposes I by-passed this error by excluding the `ms-gls` package from the requirements in `conanfile.py`.
Then we start to get errors in the compile process because it seems that the required dependencies are not supporting the compiler. 
This is what happens for package `glbinding/3.1.0` (6 of 30 to be installed) where we get the compilation error "Unsupported compiler":
```bash
In file included from C:\Morpheus\.conan2\p\b\glbinbf829c08ada13\b\src\source\glbinding\source\AbstractState.cpp:2:
In file included from C:\Morpheus\.conan2\p\b\glbinbf829c08ada13\b\src\source\glbinding\include\glbinding/AbstractState.h:8:
In file included from C:\Morpheus\.conan2\p\b\glbinbf829c08ada13\b\src\source\glbinding\include\glbinding/CallbackMask.h:6:
C:\Morpheus\.conan2\p\b\glbinbf829c08ada13\b\build\source\glbinding\include\glbinding/glbinding_features.h(361,6): error: Unsupported compiler
#    error Unsupported compiler
```
If we investigate the source file `glbinding_features.h` it seems a compiler macro issue; in fact in my opinion the Intel oneAPI DPC++/C++ Compiler should be supported because the [compiler macro signature](https://www.intel.com/content/www/us/en/developer/articles/technical/use-predefined-macros-for-specific-code-for-intel-dpcpp-compiler-intel-cpp-compiler-intel-cpp-compiler-classic.html) `__INTEL_LLVM_COMPILER` is there and should trigger the instruction `define GLBINDING_COMPILER_IS_IntelLLVM 1`:
```cpp
#elif defined(__INTEL_COMPILER) || defined(__ICC)
# undef GLBINDING_COMPILER_IS_Intel
# define GLBINDING_COMPILER_IS_Intel 1

#elif (defined(__clang__) && defined(__INTEL_CLANG_COMPILER)) || defined(__INTEL_LLVM_COMPILER)
# undef GLBINDING_COMPILER_IS_IntelLLVM
# define GLBINDING_COMPILER_IS_IntelLLVM 1
```
who knows where is the catch here... The execution then jumps at row 361 and the error message is triggered:
```cpp
#  else
#    error Unsupported compiler
#  endif
```
So, not sure what we have to do here. I have the feeling that most of the Conan packages are mainly supporting the "big three" compilers and that the support for the Intel compiler is currently more a matter of luck than of a real intention 😄 
Which is your opinion? How do we have to approach this?

Thanks.

Cheers
Gianmario