### PR TITLE
Ensure that if the stacktrace fallback is required it always has formatting support

### DIFF
--- a/libraries/core/src/morpheus/core/conformance/stacktrace.hpp
+++ b/libraries/core/src/morpheus/core/conformance/stacktrace.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <morpheus/core/conformance/version.hpp>
+
 #if __has_include(<stacktrace>)
     #include <stacktrace>
 #endif
@@ -11,7 +13,6 @@
 
     #define MORPHEUS_CURRENT_STACKTRACE ::morpheus::st_ns::stacktrace::current()
 #else
-
     #include <boost/stacktrace/stacktrace.hpp>
     namespace morpheus { namespace st_ns = boost::stacktrace; }
 

--- a/libraries/core/src/morpheus/core/conversion/adapters/std/stacktrace.hpp
+++ b/libraries/core/src/morpheus/core/conversion/adapters/std/stacktrace.hpp
@@ -6,7 +6,7 @@
 #include <string_view>
 
 // clang-format off
-#if (__cpp_lib_formatters < 202302L)
+#if (__cpp_lib_stacktrace < 202011L) or (__cpp_lib_formatters < 202302L)
 
 template <typename Allocator>
 struct morpheus::fmt_ns::formatter<morpheus::st_ns::basic_stacktrace<Allocator>>


### PR DESCRIPTION
This in particular was exposred by gcc-14 when it was build without the `--enable-libstdcxx-backtrace=yes` flag.  In this case it does not ship with the `__cpp_lib_stacktrace` enabled, but the `__cpp_lib_fomatters` flag indicated stack trace formatting is supported...

Here we need to say if we are using boost stacktrace when we need to define a formatter for it.